### PR TITLE
fix: rename evaluation_strategy to eval_strategy for newer transformers

### DIFF
--- a/training/determined/train_det.py
+++ b/training/determined/train_det.py
@@ -193,7 +193,7 @@ def main() -> None:
         logging_steps=20,
         save_steps=20,
         eval_steps=20,
-        evaluation_strategy="steps" if eval_ds is not None else "no",
+        eval_strategy="steps" if eval_ds is not None else "no",
         save_strategy="steps",
         bf16=(dtype == torch.bfloat16),
         fp16=(dtype == torch.float16),

--- a/training/scripts/train_lora_chat.py
+++ b/training/scripts/train_lora_chat.py
@@ -193,7 +193,7 @@ def main() -> None:
         logging_steps=args.logging_steps,
         save_steps=args.save_steps,
         eval_steps=args.eval_steps,
-        evaluation_strategy="steps" if eval_ds is not None else "no",
+        eval_strategy="steps" if eval_ds is not None else "no",
         save_strategy="steps",
         bf16=(dtype == torch.bfloat16),
         fp16=(dtype == torch.float16),


### PR DESCRIPTION
The transformers library renamed this parameter. Fixes training on Kaggle/Colab where newer versions are pre-installed.