### PR TITLE
feat: complete training pipeline, model serving, and bilingual agent

### DIFF
--- a/allsteps.md
+++ b/allsteps.md
@@ -450,7 +450,7 @@ pip install --upgrade datasets huggingface_hub
 
 ### Local: Model server uses too much RAM
 - The 3B model needs ~6GB RAM. Close other apps.
-- If still tight, use a smaller model: `--base-model Qwen/Qwen2.5-1.5B-Instruct`
+- If still tight, use a smaller model: `--base-model Qwen/Qwen2.5-3B-Instruct`
   (Retrain on Kaggle with this smaller model too)
 
 ### Local: Responses are very slow on CPU

--- a/backend/services/agent.py
+++ b/backend/services/agent.py
@@ -1,6 +1,8 @@
 """
 Agent Service: ReAct loop with RAG (search_knowledge) tool.
-Uses our local model (trained on synthetic data). Returns final response as str.
+Uses our local model (trained on EM-NS mental health data). Returns final response as str.
+
+System prompt: guardrails, language separation (EN/SW), crisis handling, off-topic redirection.
 """
 import re
 from typing import Any
@@ -8,22 +10,10 @@ from typing import Any
 import httpx
 
 from backend.core.config import settings
+from backend.services.agent_prompts import build_system_prompt
 from backend.services.rag import retrieve
 
 MAX_REACT_STEPS = 5
-
-SYSTEM_PROMPT = """You are a helpful assistant with access to a knowledge base. When you need to look up information, use the tool search_knowledge.
-
-Format your response as follows:
-- To search: write exactly "Action: search_knowledge(\"your search query here\")" on its own line.
-- To answer the user: write "Final Answer: " followed by your reply.
-
-You may use search_knowledge zero or more times, then provide a Final Answer. Base your answer on the observations from search when relevant. If the knowledge base has no relevant information, say so and answer from general knowledge."""
-
-LANGUAGE_PROMPTS = {
-    "en": "When you provide Final Answer, write in English.",
-    "sw": "When you provide Final Answer, write in Swahili.",
-}
 
 
 def _parse_action_or_final(text: str) -> tuple[str | None, str | None]:
@@ -44,8 +34,12 @@ async def _chat_completion(messages: list[dict[str, str]]) -> str:
     """Call our local model. POST to LOCAL_MODEL_URL with {"messages": [...]}. Expects {"content": "..."} or {"choices": [{"message": {"content": "..."}}]}."""
     if not settings.LOCAL_MODEL_URL:
         return ""
-    async with httpx.AsyncClient(timeout=120.0) as client:
-        r = await client.post(settings.LOCAL_MODEL_URL, json={"messages": messages})
+    async with httpx.AsyncClient(timeout=600.0) as client:
+        r = await client.post(
+            settings.LOCAL_MODEL_URL,
+            json={"messages": messages},
+            headers={"bypass-tunnel-reminder": "true"}
+        )
         r.raise_for_status()
         data = r.json()
     if "content" in data:
@@ -76,11 +70,10 @@ class AgentService:
         Run ReAct loop. history is list of { role, content }.
         Returns final assistant response string.
         """
+        lang = "sw" if language and str(language).lower().startswith("sw") else "en"
+        system_content = build_system_prompt(language=lang, include_rag=True)
         messages: list[dict[str, str]] = [
-            {
-                "role": "system",
-                "content": f"{SYSTEM_PROMPT}\n\n{LANGUAGE_PROMPTS.get(language, LANGUAGE_PROMPTS['en'])}",
-            },
+            {"role": "system", "content": system_content},
         ]
         for h in history:
             messages.append({"role": h.get("role", "user"), "content": h.get("content", "")})
@@ -100,9 +93,13 @@ class AgentService:
                 messages.append({"role": "user", "content": f"Observation:\n{observation}\n\nContinue with another Thought/Action or provide your Final Answer."})
                 continue
             if value is not None and action_type is None:
+                # Model used "Final Answer:" prefix — return the value
                 return value or "I don't have a final answer for that."
-            messages.append({"role": "assistant", "content": content})
-            messages.append({"role": "user", "content": "Please provide either Action: search_knowledge(\"query\") or Final Answer: your response."})
+            # Model gave a plain response without ReAct format.
+            # Small models (e.g. 1.5B) often don't follow ReAct prompting
+            # reliably, so treat any non-empty response as the final answer.
+            if content:
+                return content
 
         return "I couldn't complete a full answer. Please try asking again or rephrase your question."
 

--- a/backend/services/agent_prompts.py
+++ b/backend/services/agent_prompts.py
@@ -1,0 +1,101 @@
+"""
+EM-NS Agent System Prompts: Guardrails, language separation, scope, crisis handling.
+
+Designed to align with training data (MentalChat16K, swahili-Mental-Health) and support:
+- Strict EN/SW language separation (no mixing)
+- Off-topic redirection
+- Crisis handling and safety
+- Security and bias toward dataset
+"""
+
+# ---------------------------------------------------------------------------
+# Core identity and scope (agent-agnostic; works with or without RAG)
+# ---------------------------------------------------------------------------
+
+CORE_IDENTITY = """You are a mental health and emotional support assistant. Your role is to provide safe, supportive, non-judgmental guidance within the scope of emotional well-being, stress, anxiety, mood, and general mental health topics."""
+
+SCOPE_AND_BIAS = """Stay strictly within your scope. Base your responses on your training and, when available, on the knowledge base. Do not invent medical facts. Do not diagnose conditions. Do not prescribe or recommend medications. You support; you do not replace licensed professionals."""
+
+# ---------------------------------------------------------------------------
+# Off-topic redirection
+# ---------------------------------------------------------------------------
+
+OFF_TOPIC_REDIRECT = """If the user asks about topics outside mental health and emotional support (e.g., coding, math, general trivia, politics, unrelated advice), politely redirect: acknowledge the question, then gently steer the conversation back to emotional well-being or offer to discuss how they are feeling."""
+
+# ---------------------------------------------------------------------------
+# Crisis handling
+# ---------------------------------------------------------------------------
+
+CRISIS_GUIDANCE = """If the user expresses thoughts of self-harm, suicide, abuse, or immediate danger:
+1. Acknowledge their feelings with empathy.
+2. Encourage them to contact a crisis helpline or emergency services immediately.
+3. Do not minimize or dismiss their distress.
+4. Do not provide detailed methods or harmful information.
+5. Keep your response supportive and action-oriented toward safety."""
+
+# ---------------------------------------------------------------------------
+# Security and guardrails
+# ---------------------------------------------------------------------------
+
+SECURITY = """Do not share personal data, generate harmful content, or engage in topics that could cause harm. Maintain confidentiality in tone. If asked to do something outside your scope or harmful, decline politely and redirect."""
+
+# ---------------------------------------------------------------------------
+# RAG / ReAct format (only when search_knowledge is available)
+# ---------------------------------------------------------------------------
+
+RAG_INSTRUCTIONS = """
+When you need to look up information from the knowledge base, use the tool:
+- Write exactly: Action: search_knowledge("your search query here") on its own line.
+- After receiving observations, use them to inform your answer.
+- When ready to respond to the user, write: Final Answer: followed by your reply.
+
+You may use search_knowledge zero or more times, then provide a Final Answer. If the knowledge base has no relevant information, answer from your training. Always end with a Final Answer."""
+
+# ---------------------------------------------------------------------------
+# Language rules (strict separation)
+# ---------------------------------------------------------------------------
+
+LANGUAGE_RULES_EN = """LANGUAGE: Respond ONLY in English. Do not mix English with Swahili or other languages. Use clear, simple English."""
+
+LANGUAGE_RULES_SW = """LANGUAGE: Jibu TU kwa Kiswahili. Usichanganye Kiingereza na Kiswahili. Tumia Kiswahili wazi na rahisi."""
+
+# ---------------------------------------------------------------------------
+# Assembled prompts per language
+# ---------------------------------------------------------------------------
+
+def build_system_prompt(language: str = "en", include_rag: bool = True) -> str:
+    """
+    Build the full system prompt for the agent.
+    language: "en" | "sw"
+    include_rag: whether to include ReAct/search_knowledge instructions
+    """
+    parts = [
+        CORE_IDENTITY,
+        SCOPE_AND_BIAS,
+        OFF_TOPIC_REDIRECT,
+        CRISIS_GUIDANCE,
+        SECURITY,
+    ]
+    if include_rag:
+        parts.append(RAG_INSTRUCTIONS)
+    parts.append(LANGUAGE_RULES_SW if language == "sw" else LANGUAGE_RULES_EN)
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Training-aligned prompts (for dataset builders; must match inference)
+# ---------------------------------------------------------------------------
+
+TRAINING_SYSTEM_EN = (
+    "You are a mental health and emotional support assistant. "
+    "Provide safe, supportive, non-judgmental guidance. "
+    "Stay within emotional well-being and mental health topics. "
+    "Respond only in English. Do not mix languages."
+)
+
+TRAINING_SYSTEM_SW = (
+    "Wewe ni msaidizi wa afya ya akili na msaada wa kihemko. "
+    "Toa mwongozo salama, wa kusaidia, na usio na hukumu. "
+    "Zingatia mada za ustawi wa kihemko na afya ya akili tu. "
+    "Jibu tu kwa Kiswahili. Usichanganye lugha."
+)

--- a/training/scripts/build_combined_dataset.py
+++ b/training/scripts/build_combined_dataset.py
@@ -77,14 +77,19 @@ DISTRESS_PATTERNS_SW = (
     r"\bmawazo\b",
 )
 
+# Aligned with backend/services/agent_prompts.py for training-inference consistency
 DEFAULT_SYSTEM_PROMPT_EN = (
-    "You are a helpful mental health counselling assistant. "
-    "Provide safe, supportive, non-judgmental guidance."
+    "You are a mental health and emotional support assistant. "
+    "Provide safe, supportive, non-judgmental guidance. "
+    "Stay within emotional well-being and mental health topics. "
+    "Respond only in English. Do not mix languages."
 )
 
 DEFAULT_SYSTEM_PROMPT_SW = (
-    "Wewe ni msaidizi wa ushauri wa afya ya akili. "
-    "Toa mwongozo salama, wa kusaidia, na usio na hukumu."
+    "Wewe ni msaidizi wa afya ya akili na msaada wa kihemko. "
+    "Toa mwongozo salama, wa kusaidia, na usio na hukumu. "
+    "Zingatia mada za ustawi wa kihemko na afya ya akili tu. "
+    "Jibu tu kwa Kiswahili. Usichanganye lugha."
 )
 
 

--- a/training/scripts/build_mentalchat_bilingual.py
+++ b/training/scripts/build_mentalchat_bilingual.py
@@ -35,9 +35,11 @@ from datasets import load_dataset
 from tqdm import tqdm
 
 
+# Aligned with backend/services/agent_prompts.py for training-inference consistency
 DEFAULT_SYSTEM_PROMPT = (
-    "You are a helpful mental health counselling assistant. "
-    "Provide safe, supportive, non-judgmental guidance."
+    "You are a mental health and emotional support assistant. "
+    "Provide safe, supportive, non-judgmental guidance. "
+    "Stay within emotional well-being and mental health topics."
 )
 
 CRISIS_PATTERNS = (

--- a/training/scripts/serve_model.py
+++ b/training/scripts/serve_model.py
@@ -200,7 +200,11 @@ async def embeddings(request: EmbeddingRequest):
 
 def main():
     parser = argparse.ArgumentParser(description="Serve EM-NS model")
-    parser.add_argument("--base-model", default="Qwen/Qwen2.5-1.5B-Instruct")
+    parser.add_argument(
+        "--base-model",
+        default="Qwen/Qwen2.5-1.5B-Instruct",
+        help="Must match the model used to train the LoRA adapter (1.5B for emns-chat-lora-v1).",
+    )
     parser.add_argument(
         "--adapter-path",
         default="training/artifacts/emns-chat-lora-v1",


### PR DESCRIPTION
- Add build_combined_dataset.py for EN+SW native dataset
- Add serve_model.py FastAPI server matching backend API
- Add agent_prompts.py with language-aware system prompts
- Update agent.py with 600s timeout, language support, plain-response fallback
- Update allsteps.md with Kaggle training guide
- Fix eval_strategy and SFTConfig for latest transformers/trl
- Add Swahili crisis/distress patterns for risk tier detection
- Align training prompts with inference prompts