### PR TITLE
fix: update Dockerfile COPY paths for Railway rootDirectory=backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,9 +5,11 @@
 **/*.pyd
 
 # Virtual environments
+# (Railway rootDirectory=backend, so paths are relative to backend/)
+venv/
+.venv/
 backend/venv/
 backend/.venv/
-.venv/
 
 # Secrets — set these as Railway environment variables instead
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # ── Dependencies (cached layer) ───────────────────────────────────────────────
-COPY backend/requirements.txt ./requirements.txt
+# Railway sets rootDirectory=backend, so the build context is backend/.
+# All COPY paths are relative to backend/.
+COPY requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # ── Application code ──────────────────────────────────────────────────────────
-COPY backend/ ./backend/
+# Copy the entire backend/ context into /app/backend/ so that
+# `from backend.xxx import ...` resolves correctly from WORKDIR /app.
+COPY . ./backend/
 
 # ── Runtime config ────────────────────────────────────────────────────────────
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    # chromadb persists inside the copied backend dir
     CHROMA_PERSIST_DIR=/app/backend/chroma_data \
     PORT=8000
 


### PR DESCRIPTION
Railway auto-detects backend/ as rootDirectory, making it the build context. COPY commands must be relative to backend/, not the repo root.
- COPY requirements.txt (not backend/requirements.txt)
- COPY . ./backend/ (copies build context into /app/backend/ for import resolution)