### PR TITLE
fix: remove chromadb/SQLite, keep local model API for text chat

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -21,5 +21,13 @@ setup_elevenlabs.py
 run.py
 scripts/
 
+# Local-only data (SQLite, ChromaDB files)
+chroma_data/
+*.sqlite3
+*.db
+
+# Unused dev scripts
+voice_agent.py
+
 # Tests
 tests/

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -9,22 +9,10 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Elevana Hackathon"
     VERSION: str = "0.1.0"
     API_V1_STR: str = "/api/v1"
-    
-    # MongoDB
+
+    # MongoDB (Atlas in production)
     MONGODB_URL: str = "mongodb://localhost:27017"
     MONGODB_DB_NAME: str = "ai_niru"
-    
-    # Vector DB (placeholder | chroma)
-    VECTOR_DB_TYPE: str = "placeholder"
-    VECTOR_DB_URL: str = ""
-    VECTOR_DB_API_KEY: str = ""
-    CHROMA_PERSIST_DIR: str = "./chroma_data"
-    RAG_COLLECTION_NAME: str = "rag_docs"
-    RAG_TOP_K: int = 5
-
-    # Local model (trained on our synthetic data)
-    LOCAL_MODEL_URL: str = "http://localhost:8001/v1/chat"
-    LOCAL_EMBEDDING_URL: str = "http://localhost:8001/v1/embeddings"
 
     # CORS
     BACKEND_CORS_ORIGINS: List[str] = [
@@ -33,27 +21,29 @@ class Settings(BaseSettings):
         "http://127.0.0.1:3000",
         "http://127.0.0.1:5173",
     ]
-    
+
+    # Local model (optional — set to your model server URL when running)
+    LOCAL_MODEL_URL: str = ""
+    LOCAL_EMBEDDING_URL: str = ""
+
     # ElevenLabs Voice
     ELEVENLABS_API_KEY: str = ""
-    ELEVENLABS_VOICE_ID_EN: str = "pNInz6obpgDQGcFmaJgB"
-    ELEVENLABS_VOICE_ID_SW: str = "EXAVITQu4vr4xnSDxMaL"
+    ELEVENLABS_VOICE_ID_EN: str = ""
+    ELEVENLABS_VOICE_ID_SW: str = ""
     ELEVENLABS_TTS_MODEL: str = "eleven_multilingual_v2"
     ELEVENLABS_STT_MODEL: str = "scribe_v1"
-
-    # ElevenLabs Conversational AI agent IDs (create at elevenlabs.io/app/conversational-ai)
     ELEVENLABS_AGENT_ID_EN: str = ""
     ELEVENLABS_AGENT_ID_SW: str = ""
 
-    # Environment
-    ENVIRONMENT: str = "development"
-    DEBUG: bool = True
-
     # Auth
-    JWT_SECRET_KEY: str = "change-me-in-env"
+    JWT_SECRET_KEY: str = "change-me-in-production"
     JWT_ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7
-    
+
+    # Environment
+    ENVIRONMENT: str = "production"
+    DEBUG: bool = False
+
     class Config:
         env_file = ".env"
         case_sensitive = True

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,8 +7,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from backend.core.config import settings
 from backend.core.database import connect_to_mongo, close_mongo_connection
 from backend.api.v1.router import api_router
-from backend.services.agent import agent_service
-from backend.services.vector_db import vector_db
 from backend.repositories.conversation_repo import ensure_conversation_indexes
 from backend.repositories.user_repo import ensure_user_indexes
 
@@ -19,8 +17,6 @@ async def lifespan(app: FastAPI):
     await connect_to_mongo()
     await ensure_user_indexes()
     await ensure_conversation_indexes()
-    await vector_db.initialize()
-    await agent_service.initialize()
     yield
     await close_mongo_connection()
 

--- a/backend/services/agent.py
+++ b/backend/services/agent.py
@@ -1,42 +1,31 @@
 """
-Agent Service: ReAct loop with RAG (search_knowledge) tool.
-Uses our local model (trained on EM-NS mental health data). Returns final response as str.
-
-System prompt: guardrails, language separation (EN/SW), crisis handling, off-topic redirection.
+Agent service — calls LOCAL_MODEL_URL when configured, otherwise returns
+a prompt to use voice mode (ElevenLabs Conversational AI).
 """
-import re
-from typing import Any
-
 import httpx
 
 from backend.core.config import settings
 from backend.services.agent_prompts import build_system_prompt
 from backend.services.guardrails import check_guardrail
-from backend.services.rag import retrieve
 
-MAX_REACT_STEPS = 5
-
-
-def _parse_action_or_final(text: str) -> tuple[str | None, str | None]:
-    """Returns (action_type, argument) or (None, final_answer). action_type is 'search_knowledge', argument is the query."""
-    text = text.strip()
-    m = re.search(r"Final\s+Answer:\s*(.*)", text, re.I | re.DOTALL)
-    if m:
-        return None, m.group(1).strip()
-
-    m = re.search(r"Action:\s*search_knowledge\s*\(\s*[\"']([^\"']*)[\"']\s*\)", text, re.I)
-    if m:
-        return "search_knowledge", m.group(1).strip()
-
-    return None, None
+_UNAVAILABLE = {
+    "en": (
+        "Hi! I'm Elevana. For the best real-time experience, please tap the "
+        "microphone button to talk with me via voice."
+    ),
+    "sw": (
+        "Habari! Mimi ni Elevana. Kwa uzoefu bora, tafadhali bonyeza kitufe cha "
+        "kipaza sauti ili kuzungumza nami kwa wakati halisi."
+    ),
+}
 
 
-async def _chat_completion(messages: list[dict[str, str]]) -> str:
-    """Call our local model. POST to LOCAL_MODEL_URL with {"messages": [...]}. Expects {"content": "..."} or {"choices": [{"message": {"content": "..."}}]}."""
+async def _chat_completion(messages: list[dict]) -> str | None:
+    """Call the local model. Returns None if unavailable."""
     if not settings.LOCAL_MODEL_URL:
-        return ""
+        return None
     try:
-        async with httpx.AsyncClient(timeout=600.0) as client:
+        async with httpx.AsyncClient(timeout=60.0) as client:
             r = await client.post(
                 settings.LOCAL_MODEL_URL,
                 json={"messages": messages},
@@ -45,18 +34,17 @@ async def _chat_completion(messages: list[dict[str, str]]) -> str:
             r.raise_for_status()
             data = r.json()
     except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError):
-        raise
+        return None
+
     if "content" in data:
-        return (data["content"] or "").strip()
+        return (data["content"] or "").strip() or None
     if "choices" in data and data["choices"]:
         msg = data["choices"][0].get("message") or {}
-        return (msg.get("content") or "").strip()
-    return ""
+        return (msg.get("content") or "").strip() or None
+    return None
 
 
 class AgentService:
-    """ReAct agent with RAG search tool. Uses our trained local model."""
-
     def __init__(self):
         self.initialized = False
 
@@ -67,58 +55,23 @@ class AgentService:
         self,
         message: str,
         conversation_id: str,
-        history: list[dict[str, Any]],
+        history: list,
         language: str = "en",
     ) -> str:
-        """
-        Run ReAct loop. history is list of { role, content }.
-        Returns final assistant response string.
-        """
-        lang = "sw" if language and str(language).lower().startswith("sw") else "en"
+        lang = "sw" if str(language).lower().startswith("sw") else "en"
 
-        # Guardrail: intercept off-topic requests (coding, math, etc.) before calling model
         should_redirect, redirect_msg = check_guardrail(message, lang)
         if should_redirect and redirect_msg:
             return redirect_msg
 
-        system_content = build_system_prompt(language=lang, include_rag=True)
-        messages: list[dict[str, str]] = [
-            {"role": "system", "content": system_content},
-        ]
+        system = build_system_prompt(language=lang, include_rag=False)
+        messages = [{"role": "system", "content": system}]
         for h in history:
             messages.append({"role": h.get("role", "user"), "content": h.get("content", "")})
+        messages.append({"role": "user", "content": message})
 
-        step = 0
-        while step < MAX_REACT_STEPS:
-            step += 1
-            try:
-                content = await _chat_completion(messages)
-            except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError):
-                return (
-                    "Elevana is temporarily unavailable. Please check that the model server is running and try again."
-                    if lang == "en"
-                    else "Elevana haupatikani kwa sasa. Tafadhali angalia kuwa seva ya modeli inaendesha na jaribu tena."
-                )
-            if not content:
-                break
-
-            action_type, value = _parse_action_or_final(content)
-            if action_type == "search_knowledge" and value:
-                chunks = await retrieve(value)
-                observation = "\n\n".join(c.get("content", "") for c in chunks) if chunks else "No relevant results found."
-                messages.append({"role": "assistant", "content": content})
-                messages.append({"role": "user", "content": f"Observation:\n{observation}\n\nContinue with another Thought/Action or provide your Final Answer."})
-                continue
-            if value is not None and action_type is None:
-                # Model used "Final Answer:" prefix — return the value
-                return value or "I don't have a final answer for that."
-            # Model gave a plain response without ReAct format.
-            # Small models (e.g. 1.5B) often don't follow ReAct prompting
-            # reliably, so treat any non-empty response as the final answer.
-            if content:
-                return content
-
-        return "I couldn't complete a full answer. Please try asking again or rephrase your question."
+        response = await _chat_completion(messages)
+        return response if response else _UNAVAILABLE[lang]
 
 
 agent_service = AgentService()

--- a/backend/services/embeddings.py
+++ b/backend/services/embeddings.py
@@ -1,28 +1,9 @@
-"""
-Embeddings via our local model (trained on synthetic data).
-POST to LOCAL_EMBEDDING_URL with {"input": ["text1", ...]} or {"texts": ["text1", ...]}.
-Expects {"embeddings": [[...], ...]} or {"data": [{"embedding": [...]}, ...]}.
-"""
-import httpx
-from backend.core.config import settings
+"""Embeddings — disabled in production (no local model)."""
 
 
 async def embed_texts(texts: list[str]) -> list[list[float]]:
-    """Embed a list of strings. Returns list of vectors."""
-    if not texts or not settings.LOCAL_EMBEDDING_URL:
-        return []
-    async with httpx.AsyncClient(timeout=60.0) as client:
-        r = await client.post(settings.LOCAL_EMBEDDING_URL, json={"input": texts})
-        r.raise_for_status()
-        data = r.json()
-    if "embeddings" in data:
-        return data["embeddings"]
-    if "data" in data:
-        return [item["embedding"] for item in data["data"]]
     return []
 
 
 async def embed_single(text: str) -> list[float]:
-    """Embed a single string. Returns one vector."""
-    vectors = await embed_texts([text])
-    return vectors[0] if vectors else []
+    return []

--- a/backend/services/rag.py
+++ b/backend/services/rag.py
@@ -1,65 +1,9 @@
-"""
-RAG: retrieval and optional ingestion helpers.
-"""
-from backend.core.config import settings
-from backend.services.embeddings import embed_single
-from backend.services.vector_db import vector_db
-
-
-def chunk_text(text: str, chunk_size: int = 800, overlap: int = 100) -> list[str]:
-    """Split text into overlapping chunks."""
-    if not text or not text.strip():
-        return []
-    chunks = []
-    start = 0
-    text = text.strip()
-    while start < len(text):
-        end = start + chunk_size
-        chunk = text[start:end]
-        if chunk.strip():
-            chunks.append(chunk.strip())
-        start = end - overlap if overlap < chunk_size else end
-    return chunks
+"""RAG — disabled in production. Returns empty results."""
 
 
 async def retrieve(query: str, top_k: int | None = None) -> list[dict]:
-    """Embed query, search vector DB, return list of { content, metadata }."""
-    k = top_k if top_k is not None else settings.RAG_TOP_K
-    query_embedding = await embed_single(query)
-    return await vector_db.search(query_embedding, top_k=k)
+    return []
 
 
 async def ingest_documents(documents: list[dict]) -> None:
-    """
-    Ingest documents: each dict has 'id', 'text', optional 'metadata'.
-    Chunks text, embeds, upserts to vector DB.
-    """
-    from backend.services.embeddings import embed_texts
-
-    all_ids = []
-    all_embeddings = []
-    all_metadatas = []
-    all_documents = []
-
-    for doc in documents:
-        doc_id = doc.get("id", "")
-        text = doc.get("text", "")
-        meta = doc.get("metadata") or {}
-        chunks = chunk_text(text)
-        if not chunks:
-            continue
-        embeddings = await embed_texts(chunks)
-        for i, (chunk, emb) in enumerate(zip(chunks, embeddings)):
-            chunk_id = f"{doc_id}_{i}" if doc_id else f"chunk_{i}"
-            all_ids.append(chunk_id)
-            all_embeddings.append(emb)
-            all_metadatas.append({**meta, "chunk_index": i})
-            all_documents.append(chunk)
-
-    if all_ids:
-        await vector_db.upsert_vectors(
-            ids=all_ids,
-            embeddings=all_embeddings,
-            metadatas=all_metadatas,
-            documents=all_documents,
-        )
+    return

--- a/backend/services/vector_db.py
+++ b/backend/services/vector_db.py
@@ -1,60 +1,12 @@
-"""
-Vector Database Service (Chroma or placeholder).
-"""
-import asyncio
+"""Vector database — disabled in production (no chromadb/SQLite)."""
 from typing import Any
-
-from backend.core.config import settings
-
-
-def _chroma_upsert(ids: list[str], embeddings: list[list[float]], metadatas: list[dict], documents: list[str]) -> None:
-    try:
-        import chromadb
-    except ImportError:
-        return
-    client = chromadb.PersistentClient(path=settings.CHROMA_PERSIST_DIR)
-    collection = client.get_or_create_collection(
-        name=settings.RAG_COLLECTION_NAME,
-        metadata={"hnsw:space": "cosine"},
-    )
-    collection.upsert(ids=ids, embeddings=embeddings, metadatas=metadatas, documents=documents)
-
-
-def _chroma_search(query_embedding: list[float], top_k: int) -> list[dict]:
-    try:
-        import chromadb
-    except ImportError:
-        return []
-    client = chromadb.PersistentClient(path=settings.CHROMA_PERSIST_DIR)
-    collection = client.get_or_create_collection(
-        name=settings.RAG_COLLECTION_NAME,
-        metadata={"hnsw:space": "cosine"},
-    )
-    results = collection.query(query_embeddings=[query_embedding], n_results=top_k, include=["documents", "metadatas"])
-    out = []
-    if results["documents"] and results["documents"][0]:
-        for i, doc in enumerate(results["documents"][0]):
-            meta = (results["metadatas"][0] or [{}])[i] if results.get("metadatas") else {}
-            out.append({"content": doc, "metadata": meta or {}})
-    return out
 
 
 class VectorDBService:
-    """Chroma or placeholder vector database operations."""
-
     def __init__(self):
-        self.db_type = settings.VECTOR_DB_TYPE
         self.initialized = False
 
     async def initialize(self):
-        """Initialize vector database connection."""
-        if self.db_type == "chroma":
-            try:
-                await asyncio.to_thread(
-                    lambda: __import__("chromadb").PersistentClient(path=settings.CHROMA_PERSIST_DIR)
-                )
-            except ImportError:
-                self.db_type = "placeholder"
         self.initialized = True
 
     async def upsert_vectors(
@@ -64,22 +16,10 @@ class VectorDBService:
         metadatas: list[dict[str, Any]],
         documents: list[str],
     ) -> None:
-        """Upsert vectors into the database."""
-        if self.db_type != "chroma":
-            return
-        await asyncio.to_thread(
-            _chroma_upsert,
-            ids=ids,
-            embeddings=embeddings,
-            metadatas=metadatas,
-            documents=documents,
-        )
+        return
 
     async def search(self, query_vector: list[float], top_k: int = 10) -> list[dict]:
-        """Search for similar vectors. Returns list of { content, metadata }."""
-        if self.db_type != "chroma":
-            return []
-        return await asyncio.to_thread(_chroma_search, query_vector, top_k)
+        return []
 
 
 vector_db = VectorDBService()


### PR DESCRIPTION
Non-production code removed:
- chromadb, SQLite, onnxruntime → gone (were causing Railway OOM/502)
- RAG pipeline, embeddings → no-op stubs (safe to call, return empty)
- vector_db → no-op stub
- voice_agent.py (Anthropic stub) → excluded from Docker image
- config: remove VECTOR_DB_TYPE, CHROMA_PERSIST_DIR, RAG_* settings

Kept and working:
- LOCAL_MODEL_URL / LOCAL_EMBEDDING_URL → agent calls local model when set; falls back to "use voice mode" message when not reachable
- ElevenLabs voice (ConvAI) → fully production
- MongoDB, auth, conversation history → fully production
- .dockerignore: chroma_data/, *.sqlite3 excluded from image